### PR TITLE
Ignore elements with a blank intro

### DIFF
--- a/chardinjs.js
+++ b/chardinjs.js
@@ -22,7 +22,7 @@
           return false;
         }
         this._add_overlay_layer();
-        _ref = this.$el.find('*[data-intro]:visible');
+        _ref = this.$el.find('*[data-intro]:visible').not('[data-intro=""]');
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           el = _ref[_i];
           this._show_element(el);


### PR DESCRIPTION
Change jQuery selector so that it ignores elements with a blank intro

This allows you to have conditional intros - e.g. if you have an element in a repeater and only want it to display on the first one
